### PR TITLE
[CHORE] Expand multi-camera guidance

### DIFF
--- a/.codex/planning/aur_packaging_review.md
+++ b/.codex/planning/aur_packaging_review.md
@@ -1,0 +1,11 @@
+# AUR Packaging Review Guide
+
+## Resources
+- [Arch PKGBUILD guidelines](https://wiki.archlinux.org/title/PKGBUILD)
+- [AUR submission guide](https://wiki.archlinux.org/title/Arch_User_Repository)
+
+## Review Steps for Task Masters
+1. Survey existing AUR packages for Python-based TUIs to mirror directory structure and dependencies.
+2. Draft a `PKGBUILD` with `pkgname`, `pkgver`, `source`, `sha256sums`, `depends=('uv')`, and an install step for the CLI entry point.
+3. Generate `.SRCINFO` via `makepkg --printsrcinfo > .SRCINFO` and ensure both files stay in sync.
+4. Test the package in a clean Arch chroot before publishing to the AUR.

--- a/.codex/planning/kde_wayland_review.md
+++ b/.codex/planning/kde_wayland_review.md
@@ -1,0 +1,35 @@
+# KDE Wayland Screen Locker Review Guide
+
+## Repository
+- [KDE/kscreenlocker](https://github.com/KDE/kscreenlocker)
+
+## Key Interfaces
+### org.freedesktop.ScreenSaver
+```xml
+<method name="Lock"/>
+<method name="GetSessionIdleTime"/>
+<method name="Inhibit">
+  <arg name="application_name" type="s" direction="in"/>
+  <arg name="reason_for_inhibit" type="s" direction="in"/>
+  <arg name="cookie" type="u" direction="out"/>
+</method>
+```
+
+### Interface::Lock
+```cpp
+void Interface::Lock() {
+    if (!KAuthorized::authorizeAction("lock_screen")) {
+        return;
+    }
+    m_daemon->lock(calledFromDBus() ? EstablishLock::Immediate : EstablishLock::Delayed);
+}
+```
+
+### Power Management Inhibition
+`powermanagement_inhibition.cpp` and the `PowerInhibitor` helper in `interface.cpp` use the `org.kde.Solid.PowerManagement.PolicyAgent` service to keep the session awake while locked and release the inhibition cookie on exit.
+
+## Review Steps for Task Masters
+1. Clone the repo and inspect `dbus/org.freedesktop.ScreenSaver.xml` for DBus methods.
+2. Review `interface.cpp` for lock/unlock and inhibition logic.
+3. Examine `powermanagement_inhibition.cpp` for DBus calls that inhibit power management.
+4. Confirm `ActiveChanged` signals for responding to lock/unlock events.

--- a/.codex/planning/plan.md
+++ b/.codex/planning/plan.md
@@ -1,0 +1,25 @@
+# Midori AI Vision TUI Plan
+
+## Goal
+Create a Rich-based TUI application that captures images from the user, maintains a dataset, and trains a YOLO model when the system is idle. The app should manage screen locking on KDE Wayland and prevent the system from sleeping while active.
+
+## Components
+- **TUI Layer:** Use the [Textual](https://github.com/Textualize/textual) framework for a rich terminal interface.
+- **Model:** Start with Ultralytics YOLO (v8 or newer). Allow replacement with other YOLO variants.
+- **Dataset Management:** Allow users to add existing images or capture new photos through the TUI. After each capture, display the photo and let the user draw bounding boxes around the person’s face **and full body** using an OpenCV `selectROI` window or keyboard controls. Tag each box with the selected user name and write YOLO-format label file(s) (`class x_center y_center width height`, normalized 0–1) under `dataset/labels/` while saving the image under `dataset/images/`. Track whether each sample has been used in training and log the last epoch trained.
+- **Camera Management:** Support multiple cameras (aim for up to 20 views). Provide TUI controls to select a camera for capture and store images and labels under camera-specific subdirectories. Presence detection should scan all configured cameras.
+- **Access Control:** Maintain a whitelist of authorized users who can unlock the session. Provide TUI actions to add or remove allowed individuals.
+- **Profile Storage:** Encrypt authorized user profiles with a hash derived from the trained model. During retraining, keep a temporary unencrypted backup and re-encrypt once complete.
+- **Training Scheduler:**
+  - Train on CPU during idle periods or when the user requests retraining.
+  - Config file (e.g., `config.toml`) stores paths, idle threshold, epoch counts, and hardware settings.
+- **Screen Lock Control:**
+  - Detect authorized user presence with the model across all configured cameras.
+  - Poll each camera for 1s every 10s. If no authorized user is seen on any feed, increase checks to every 5s for 1s until return.
+  - Unlock after a short delay when a permitted user sits down.
+  - Lock after ~30s of absence.
+- **Sleep Inhibition:** Use `org.freedesktop.ScreenSaver.Inhibit` to keep the system awake while the app runs.
+- **Packaging:** Ship an Arch Linux AUR package in an `aur/` folder targeting KDE Wayland on Arch.
+
+## Open Questions
+- Balancing training time with usability on low-end CPUs.

--- a/.codex/planning/textual_review.md
+++ b/.codex/planning/textual_review.md
@@ -1,0 +1,17 @@
+# Textual TUI Review Guide
+
+## Repository
+- [Textualize/textual](https://github.com/Textualize/textual)
+
+## Highlights
+- Cross-platform terminal and web UI from one codebase.
+- Rich widget system with CSS-like styling and reactive events.
+- Built-in testing tools for TUI components.
+- Can interoperate with external libraries like OpenCV by running blocking tasks in worker threads.
+
+## Review Steps for Task Masters
+1. Clone the repo and read `README.md` for core concepts and examples.
+2. Explore `examples/` to understand layout and widget usage.
+3. Examine `src/textual/app.py` for the `App` base class and review widgets under `src/textual/widgets/`.
+4. Check `examples/camera.py` or similar demos for handling image previews and async tasks.
+5. Check `tests/` for patterns in testing interactive components.

--- a/.codex/planning/yolo_models_review.md
+++ b/.codex/planning/yolo_models_review.md
@@ -1,0 +1,37 @@
+# YOLO Model Review Guide
+
+## Repositories
+- [Ultralytics](https://github.com/ultralytics/ultralytics) – YOLOv8/YOLO11 suite.
+- [WongKinYiu/yolov9](https://github.com/WongKinYiu/yolov9) – YOLOv9 research implementation.
+
+## Training Examples
+### Ultralytics
+```python
+from ultralytics import YOLO
+model = YOLO("yolo11n.pt")
+train_results = model.train(
+    data="coco8.yaml",
+    epochs=100,
+    imgsz=640,
+    device="cpu",
+)
+```
+
+### YOLOv9
+```bash
+python train_dual.py --workers 8 --device 0 --batch 16 --data data/coco.yaml \
+  --img 640 --cfg models/detect/yolov9-c.yaml --weights '' --name yolov9-c \
+  --hyp hyp.scratch-high.yaml --min-items 0 --epochs 500 --close-mosaic 15
+```
+
+## Annotation Format
+- YOLO labels use one text file per image with lines in the form `class x_center y_center width height`,
+  where coordinates are normalized 0–1 relative to image size.
+- Ultralytics parses these files via `ultralytics/data/utils.py`; review this module to confirm dataset structure.
+
+## Review Steps for Task Masters
+1. Clone the repos and inspect each `README.md` for setup and training instructions.
+2. In Ultralytics, examine `ultralytics/models/yolo/detect/train.py` for the `DetectionTrainer` class and its dataset loading.
+3. In YOLOv9, review `train_dual.py` for CLI training flags and config dependencies.
+4. Check `ultralytics/data/utils.py` to verify label parsing and confirm the annotation format above.
+5. Note CPU training options, dataset layouts, and differences in command-line flags or features.

--- a/.codex/tasks/00a1dfed-aur-package.md
+++ b/.codex/tasks/00a1dfed-aur-package.md
@@ -1,0 +1,7 @@
+# Finalize AUR package
+
+- Complete `aur/PKGBUILD` with `pkgname`, `pkgver()` function, `source` tarball URL, `sha256sums`, and `depends=('uv')`.
+- Add `build()` and `package()` functions that install the Textual TUI entry point under `/usr/bin`.
+- Run `updpkgsums` then generate `.SRCINFO` via `makepkg --printsrcinfo > .SRCINFO`.
+- Use `makepkg -si` inside a clean Arch chroot to verify installation and runtime, confirming that DBus calls and training can be invoked.
+- Reference: `.codex/planning/aur_packaging_review.md`.

--- a/.codex/tasks/31b76dd4-profile-encryption.md
+++ b/.codex/tasks/31b76dd4-profile-encryption.md
@@ -1,0 +1,6 @@
+# Secure authorized profile storage
+
+- Serialize whitelist profiles under `~/.config/midori-ai/whitelist.json` and encrypt using a key derived from `sha256` of the trained model weights.
+- Use `cryptography.fernet` for symmetric encryption; keep a temporary plaintext copy only during retraining, then re-encrypt with the new model hash.
+- Expose TUI actions to add/remove users, trigger encryption/decryption, show when the stored hash differs from the active model, and regenerate the key after training completes.
+- Reference: `.codex/planning/plan.md`.

--- a/.codex/tasks/4750a2a9-yolo-training-scheduler.md
+++ b/.codex/tasks/4750a2a9-yolo-training-scheduler.md
@@ -1,0 +1,7 @@
+# Build YOLO training scheduler
+
+- Use the Ultralytics `YOLO` Python API and its `engine/trainer.py` (`DetectionTrainer`) to train on CPU (`device='cpu'`) against the dataset of labeled faces and full bodies aggregated from all camera folders. Allow switching to the YOLOv9 CLI (`train.py --device cpu`) for experimentation.
+- Implement an idle monitor that checks `GetSessionIdleTime` via DBus and triggers training when idle exceeds the configured threshold or when the user requests retraining in the TUI.
+- Load settings such as dataset path, epochs, batch size, and idle threshold from `config.toml` using `tomllib`; generate a temporary YAML file pointing to all `dataset/images/**` and `dataset/labels/**` before each training run.
+- After training, save new weights, update the whitelist profile hash, and mark dataset entries with the last trained epoch.
+- Reference: `.codex/planning/plan.md`, `.codex/planning/yolo_models_review.md`.

--- a/.codex/tasks/6e8cfdfd-kde-dbus-lock.md
+++ b/.codex/tasks/6e8cfdfd-kde-dbus-lock.md
@@ -1,0 +1,7 @@
+# Integrate KDE screen lock control
+
+- Use DBus `org.freedesktop.ScreenSaver` methods `Lock`, `GetSessionIdleTime`, `Inhibit`, and `UnInhibit`; store the returned inhibition cookie.
+- Subscribe to the `ActiveChanged` signal to respond to external locks/unlocks and mirror state in the TUI.
+- Poll each configured camera every 10 s via the trained YOLO model; when no authorized face or body is detected on any feed, increase polling to every 5 s and issue a `Lock` after 30 s of absence.
+- Unlock by calling `SetActive false` or `SimulateUserActivity` once an authorized user is recognized, and release the inhibition cookie via the `PowerInhibitor` helper when the app exits.
+- Reference: `.codex/planning/plan.md`, `.codex/planning/kde_wayland_review.md`.

--- a/.codex/tasks/cdab7f1c-tui-photo-labeling.md
+++ b/.codex/tasks/cdab7f1c-tui-photo-labeling.md
@@ -1,0 +1,7 @@
+# Implement photo capture and labeling TUI
+
+- Build a Textual `App` that presents controls to preview **and switch between** multiple cameras via `opencv-python` (`cv2.VideoCapture`).
+- When an image is captured, open `cv2.selectROI` dialogs so the user can draw bounding boxes around both the face and the full body.
+- After the boxes are confirmed, prompt for the subject’s name from the whitelist and write image files to `dataset/images/<camera_id>/` with matching YOLO-format label file(s) (`class x_center y_center width height`, normalized 0–1) in `dataset/labels/<camera_id>/`.
+- List existing images grouped by user and camera and allow deletion, relabeling, or re-boxing; maintain a JSON index tracking whether each sample has been used in training and the last epoch it was trained on.
+- Reference: `.codex/planning/plan.md`, `.codex/planning/textual_review.md`.

--- a/aur/.SRCINFO
+++ b/aur/.SRCINFO
@@ -1,0 +1,10 @@
+pkgbase = midori-ai-hello
+pkgdesc = Vision TUI that trains YOLO models and manages KDE screen lock
+pkgver = 0.0.0
+pkgrel = 1
+url = https://github.com/midori-ai-oss/Midori-AI-Hello
+arch = any
+license = MIT
+depends = uv
+
+pkgname = midori-ai-hello

--- a/aur/PKGBUILD
+++ b/aur/PKGBUILD
@@ -1,0 +1,16 @@
+# Maintainer: TODO
+pkgname=midori-ai-hello
+pkgver=0.0.0
+pkgrel=1
+pkgdesc="Vision TUI that trains YOLO models and manages KDE screen lock"
+arch=('any')
+url="https://github.com/midori-ai-oss/Midori-AI-Hello"
+license=('MIT')
+depends=('uv')
+source=()
+sha256sums=()
+
+package() {
+  # TODO: install the application files
+  :
+}


### PR DESCRIPTION
## Summary
- Expand plan with face and body labeling plus camera management for up to 20 feeds
- Clarify TUI photo task with multi-camera capture and dual bounding boxes
- Update training and lock tasks to scan all cameras and train on full-body data

## Testing
- `uv sync`
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_b_689cda9b6248832c96fc97add078a0d6