### PR TITLE
[FIX] Register CLI entry point

### DIFF
--- a/.codex/implementation/cli-entrypoint.md
+++ b/.codex/implementation/cli-entrypoint.md
@@ -1,0 +1,3 @@
+# CLI Entry Point
+
+The `midori-ai-hello` package exposes a console script named `midori_ai_hello` (and `midori-ai-hello`) which executes `midori_ai_hello.__main__:main`. This allows running the tool with `uv run midori_ai_hello` from the project root.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,10 @@ dependencies = [
     "ultralytics>=8.3.179",
 ]
 
+[project.scripts]
+"midori-ai-hello" = "midori_ai_hello.__main__:main"
+midori_ai_hello = "midori_ai_hello.__main__:main"
+
 [build-system]
 requires = ["setuptools>=61", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/src/tests/test_main.py
+++ b/src/tests/test_main.py
@@ -1,4 +1,5 @@
 import pytest
+import subprocess
 from midori_ai_hello.__main__ import main
 
 
@@ -14,3 +15,9 @@ def test_main_version(capsys):
     assert excinfo.value.code == 0
     captured = capsys.readouterr()
     assert "0.1.0" in captured.out
+
+
+def test_cli_entrypoint():
+    result = subprocess.run(["midori_ai_hello", "--version"], capture_output=True, text=True)
+    assert result.returncode == 0
+    assert "0.1.0" in result.stdout


### PR DESCRIPTION
## Summary
- expose `midori_ai_hello` as an installable console script
- document the CLI entry point and test that the script runs

## Testing
- `uv run midori_ai_hello --version`
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_b_689fa262c584832ca2c3388875e19e03