### PR TITLE
[FIX] Handle empty camera list

### DIFF
--- a/.codex/implementation/tui-photo-labeling.md
+++ b/.codex/implementation/tui-photo-labeling.md
@@ -12,6 +12,8 @@ from multiple cameras and writing YOLO-format labels.
 - `CaptureScreen` binds `c` to capture a frame and `n` to cycle cameras.
   Capturing opens `cv2.selectROI` dialogs for face and body regions
   before prompting for the subject name.
+  When no cameras are detected, the screen remains idle without
+  attempting to open a device.
 
 See planning notes in `.codex/planning/plan.md` and
 `.codex/planning/textual_review.md` for the broader TUI design.

--- a/midori-ai-hello/capture_screen.py
+++ b/midori-ai-hello/capture_screen.py
@@ -91,13 +91,15 @@ class CaptureScreen(Screen):
             self._open_camera()
 
     def _open_camera(self) -> None:
-        if cv2 is None:
+        if cv2 is None or not self.cameras:
             return
         if self._cap:
             self._cap.release()
         self._cap = cv2.VideoCapture(self.cameras[self._current])
 
     def action_next_camera(self) -> None:
+        if not self.cameras:
+            return
         self._current = (self._current + 1) % len(self.cameras)
         self._open_camera()
 

--- a/src/tests/test_tui_labeler.py
+++ b/src/tests/test_tui_labeler.py
@@ -5,7 +5,7 @@ from pathlib import Path
 import numpy as np
 import pytest
 
-from midori_ai_hello.capture_screen import cv2, list_cameras, save_sample
+from midori_ai_hello.capture_screen import CaptureScreen, cv2, list_cameras, save_sample
 
 
 @pytest.mark.skipif(cv2 is None, reason="opencv not available")
@@ -38,3 +38,9 @@ def test_save_sample_writes_image_and_label(tmp_path: Path):
     lines = label_path.read_text().strip().splitlines()
     assert lines[0].startswith("0 ")
     assert lines[1].startswith("1 ")
+
+
+def test_capture_screen_handles_empty_camera_list(tmp_path: Path):
+    screen = CaptureScreen(tmp_path, cameras=[])
+    screen._open_camera()
+    assert screen._cap is None


### PR DESCRIPTION
## Summary
- avoid IndexError when no cameras are detected
- document idle behavior of CaptureScreen without cameras
- add regression test for empty camera list

## Testing
- `uv sync`
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a0857d1084832ca6a4e347d2f77cc4