### PR TITLE
Implement verbose file logging

### DIFF
--- a/.codex/implementation/verbose-file-logging.md
+++ b/.codex/implementation/verbose-file-logging.md
@@ -1,0 +1,9 @@
+# Verbose File Logging
+
+Adds configurable logging that writes all debug output to `midori-ai-hello.log` while controlling console verbosity with `--log-level` or the `LOG_LEVEL` environment variable.
+
+- Log file is created in the current working directory.
+- Console defaults to `INFO`; pass `--log-level DEBUG` for more detail.
+- Modules emit additional debug information for camera setup and capture actions.
+- Additional components such as the Textual app, screen lock manager, training
+  scheduler, DBus helper, and whitelist manager now log key lifecycle events.

--- a/.codex/tasks/ready-to-review/2c7ca1ae-verbose-logging.md
+++ b/.codex/tasks/ready-to-review/2c7ca1ae-verbose-logging.md
@@ -1,0 +1,17 @@
+# Verbose file logging
+
+## Problem
+Running the TUI produces no log output and makes debugging difficult.
+
+## Task
+Add more verbose logging with file output so camera and TUI activity can be inspected after running.
+
+## Steps
+- [x] Introduce a log configuration that writes DEBUG-level output to a file (e.g., `midori-ai-hello.log`) while preserving existing console info.
+- [x] Update `midori_ai_hello.__main__` to initialize the logging config early and respect a `--log-level` or `LOG_LEVEL` env var.
+- [x] Ensure modules like `presence_service` and `capture_screen` emit useful debug messages for camera discovery and capture actions.
+- [x] Document the logging behavior and configuration options in `.codex/implementation/`.
+- [x] Add tests verifying log file creation and sample log entries when running core components.
+
+## Context
+Requested after observing that the TUI prompts to capture images without emitting any diagnostic logs, complicating issue triage.

--- a/midori-ai-hello/capture_screen.py
+++ b/midori-ai-hello/capture_screen.py
@@ -77,6 +77,7 @@ def save_sample(
     face_line = "0 {} {} {} {}".format(*_box_to_yolo(face_box, w, h))
     body_line = "1 {} {} {} {}".format(*_box_to_yolo(body_box, w, h))
     label_path.write_text(f"{face_line}\n{body_line}\n")
+    log.info("Saved sample image %s and labels %s", image_path, label_path)
     return image_path, label_path
 
 
@@ -126,6 +127,7 @@ class CaptureScreen(Screen):
     def action_capture(self) -> None:
         if cv2 is None or not self._cap:
             return
+        log.debug("Capturing frame from camera index %s", self.cameras[self._current])
         ok, frame = self._cap.read()
         if not ok:
             return
@@ -133,4 +135,11 @@ class CaptureScreen(Screen):
         body = cv2.selectROI("body", frame, showCrosshair=True)
         cv2.destroyAllWindows()
         name = input("Subject name: ")
-        save_sample(frame, face, body, name, str(self.cameras[self._current]), self.dataset_path)
+        save_sample(
+            frame,
+            face,
+            body,
+            name,
+            str(self.cameras[self._current]),
+            self.dataset_path,
+        )

--- a/midori-ai-hello/presence_service.py
+++ b/midori-ai-hello/presence_service.py
@@ -44,6 +44,11 @@ class CameraPresenceService:
         self._present = False
         self._present_interval = present_interval
         self._absent_interval = absent_interval
+        log.debug(
+            "Initialised presence service with cameras %s using model %s",
+            cameras,
+            model_path,
+        )
 
     def add_listener(self, callback: Listener) -> None:
         """Register *callback* for presence changes."""
@@ -68,7 +73,9 @@ class CameraPresenceService:
 
         if YOLO is None:  # pragma: no cover - dependency missing
             return
+        log.debug("Loading YOLO model from %s", self._model_path)
         model = YOLO(self._model_path)
+        log.debug("Starting presence polling loop")
         try:
             while True:
                 present = await asyncio.to_thread(self._scan_once, model)

--- a/midori-ai-hello/whitelist.py
+++ b/midori-ai-hello/whitelist.py
@@ -14,14 +14,18 @@ application can detect when the active model has changed.
 
 from __future__ import annotations
 
-from pathlib import Path
 import base64
 import hashlib
 import json
+import logging
 import uuid
+from pathlib import Path
 from typing import List
 
 from cryptography.fernet import Fernet
+
+
+log = logging.getLogger(__name__)
 
 
 class WhitelistManager:
@@ -34,6 +38,7 @@ class WhitelistManager:
         self.whitelist_file = self.config_dir / "whitelist.json"
         self.hash_file = self.config_dir / "whitelist.hash"
         self.uuid_file = self.config_dir / "hellouuid.txt"
+        log.debug("WhitelistManager initialised at %s", self.config_dir)
 
     # ------------------------------------------------------------------
     # Key handling
@@ -100,12 +105,14 @@ class WhitelistManager:
         if name not in profiles:
             profiles.append(name)
             self._write(profiles)
+            log.info("Added user %s to whitelist", name)
 
     def remove_user(self, name: str) -> None:
         profiles = self._read()
         if name in profiles:
             profiles.remove(name)
             self._write(profiles)
+            log.info("Removed user %s from whitelist", name)
 
     def users(self) -> List[str]:
         return self._read()

--- a/src/tests/test_logging.py
+++ b/src/tests/test_logging.py
@@ -1,0 +1,71 @@
+from pathlib import Path
+import logging
+import asyncio
+
+import midori_ai_hello.__main__ as cli
+from midori_ai_hello.yolo_train import YOLOTrainingScheduler
+from midori_ai_hello.screen_lock_manager import ScreenLockManager
+
+
+def test_logging_file_creation(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    cli.configure_logging("INFO")
+    logging.getLogger(__name__).debug("debug message")
+    log_file = tmp_path / "midori-ai-hello.log"
+    assert log_file.exists()
+    contents = log_file.read_text()
+    assert "debug message" in contents
+
+
+def test_scheduler_training_logged(tmp_path, caplog):
+    async def run() -> bool:
+        config_path = tmp_path / "config.yaml"
+        dataset = tmp_path / "dataset"
+        dataset.mkdir()
+        config_path.write_text(
+            "dataset: {}\nidle_threshold: 0\nepochs: 1\nbatch: 1\nmodel: model.pt\n".format(
+                dataset
+            )
+        )
+
+        class DummyLocker:
+            async def get_idle_time(self) -> int:
+                return 10
+
+        scheduler = YOLOTrainingScheduler(DummyLocker(), config_path)
+        scheduler._train = lambda: None  # type: ignore
+        caplog.set_level(logging.INFO)
+        return await scheduler.maybe_train()
+
+    triggered = asyncio.run(run())
+    assert triggered
+    assert "Starting training run" in caplog.text
+
+
+def test_screen_lock_manager_logs(caplog):
+    async def run() -> None:
+        class DummyLocker:
+            async def add_active_changed_handler(self, handler):
+                self.handler = handler
+
+            async def set_active(self, active: bool) -> None:
+                pass
+
+            async def lock(self) -> None:
+                pass
+
+        class DummyPresence:
+            def add_listener(self, callback):
+                self.callback = callback
+
+        locker = DummyLocker()
+        presence = DummyPresence()
+        mgr = ScreenLockManager(locker, presence, absent_timeout=0.01)
+        caplog.set_level(logging.DEBUG)
+        await mgr.start()
+        presence.callback(False)
+        await asyncio.sleep(0.02)
+
+    asyncio.run(run())
+    assert "Screen locked due to absence" in caplog.text
+


### PR DESCRIPTION
## Summary
- add debug and info logs across the Textual app, screen lock manager, training scheduler, DBus helper, and whitelist manager
- document extended logging coverage
- test logging from training scheduler and screen lock manager

## Testing
- `uv run pytest -q`


------
https://chatgpt.com/codex/tasks/task_b_68a1ac71fed8832c950fe459529c1230