### PR TITLE
[FIX] Cancel screen lock manager task and auto-detect cameras

### DIFF
--- a/.codex/implementation/config-management.md
+++ b/.codex/implementation/config-management.md
@@ -13,3 +13,6 @@ The application stores settings in ``config.yaml`` using the following keys:
 
 Saving the configuration automatically creates camera-specific directories
 under ``dataset/images/<camera_id>`` and ``dataset/labels/<camera_id>``.
+When ``cameras`` is empty, ``MidoriApp`` calls ``list_cameras()`` to
+automatically detect available webcams. Numeric IDs stored as strings
+are coerced to integers before opening devices.

--- a/.codex/implementation/screen-lock-manager.md
+++ b/.codex/implementation/screen-lock-manager.md
@@ -8,3 +8,5 @@ screen locker via `KDEScreenLocker`.
   unlock the session.
 - Lock state changes are reported back to the TUI through a callback so the
   current state can be displayed to the user.
+- The application retains the startup task and cancels it during shutdown to
+  prevent pending-task warnings.

--- a/.codex/implementation/tui-photo-labeling.md
+++ b/.codex/implementation/tui-photo-labeling.md
@@ -5,6 +5,8 @@ from multiple cameras and writing YOLO-format labels.
 
 - `list_cameras(max_devices=10)` probes sequential indices with
   `cv2.VideoCapture` to discover available cameras.
+- `MidoriApp` falls back to `list_cameras()` when no cameras are
+  configured in `config.yaml`, ensuring available webcams are detected.
 - `save_sample` stores an image under
   `dataset/images/<camera_id>/` and writes a matching label file under
   `dataset/labels/<camera_id>/` with normalized face (`class 0`) and body
@@ -14,6 +16,9 @@ from multiple cameras and writing YOLO-format labels.
   before prompting for the subject name.
   When no cameras are detected, the screen remains idle without
   attempting to open a device.
+  Numeric camera IDs supplied as strings are coerced to integers, and
+  `_open_camera` logs distinct warnings for missing OpenCV versus an
+  empty camera list.
 
 See planning notes in `.codex/planning/plan.md` and
 `.codex/planning/textual_review.md` for the broader TUI design.

--- a/midori-ai-hello/capture_screen.py
+++ b/midori-ai-hello/capture_screen.py
@@ -89,10 +89,15 @@ class CaptureScreen(Screen):
         ("n", "next_camera", "Next camera"),
     ]
 
-    def __init__(self, dataset_path: Path, cameras: Iterable[int] | None = None) -> None:
+    def __init__(
+        self, dataset_path: Path, cameras: Iterable[int | str] | None = None
+    ) -> None:
         super().__init__()
         self.dataset_path = Path(dataset_path)
-        self.cameras = list(cameras) if cameras is not None else [0]
+        raw = list(cameras) if cameras is not None else [0]
+        self.cameras = [
+            int(c) if isinstance(c, str) and c.isdigit() else c for c in raw
+        ]
         self._current = 0
         self._cap: cv2.VideoCapture | None = None
 
@@ -104,8 +109,11 @@ class CaptureScreen(Screen):
             self._open_camera()
 
     def _open_camera(self) -> None:
-        if cv2 is None or not self.cameras:
-            log.warning("No cameras configured or OpenCV missing")
+        if cv2 is None:
+            log.warning("OpenCV not available; cannot open cameras")
+            return
+        if not self.cameras:
+            log.warning("No cameras configured")
             return
         if self._cap:
             self._cap.release()

--- a/src/tests/test_app.py
+++ b/src/tests/test_app.py
@@ -3,6 +3,7 @@ import asyncio
 
 from midori_ai_hello.app import MidoriApp
 from midori_ai_hello.config import Config
+from midori_ai_hello.capture_screen import CaptureScreen
 
 
 class DummyScheduler:
@@ -26,3 +27,70 @@ def test_manual_retrain(tmp_path: Path) -> None:
     app = MidoriApp(tmp_path / "config.yaml", scheduler=scheduler)
     asyncio.run(app.action_retrain())
     assert scheduler.calls == [True]
+
+
+def test_quit_cancels_background_tasks(tmp_path: Path) -> None:
+    cfg = Config(
+        dataset=str(tmp_path / "data"),
+        epochs=1,
+        batch=1,
+        idle_threshold=0,
+        model="yolo.pt",
+    )
+    cfg.save(tmp_path / "config.yaml")
+    scheduler = DummyScheduler()
+
+    class DummyLocker:
+        async def add_active_changed_handler(self, handler):
+            self.handler = handler
+
+    app = MidoriApp(
+        tmp_path / "config.yaml", scheduler=scheduler, locker=DummyLocker()
+    )
+
+    async def run() -> None:
+        app.on_mount()
+        await asyncio.sleep(0)
+        assert app._lock_task is not None
+        assert app._train_task is not None
+        app.action_quit()
+        await asyncio.sleep(0)
+
+    asyncio.run(run())
+    assert app._lock_task is not None and app._lock_task.done()
+    assert app._train_task is not None and app._train_task.cancelled()
+
+
+def test_app_detects_cameras_when_config_empty(
+    monkeypatch, tmp_path: Path
+) -> None:
+    cfg = Config(
+        dataset=str(tmp_path / "data"),
+        epochs=1,
+        batch=1,
+        idle_threshold=0,
+        model="yolo.pt",
+        cameras=[],
+    )
+    cfg.save(tmp_path / "config.yaml")
+    monkeypatch.setattr("midori_ai_hello.app.list_cameras", lambda: [42])
+    scheduler = DummyScheduler()
+
+    class DummyLocker:
+        async def add_active_changed_handler(self, handler):
+            self.handler = handler
+
+    app = MidoriApp(
+        tmp_path / "config.yaml", scheduler=scheduler, locker=DummyLocker()
+    )
+
+    async def run() -> None:
+        app.on_mount()
+        await asyncio.sleep(0)
+        screen = app.get_screen("capture")
+        assert isinstance(screen, CaptureScreen)
+        assert screen.cameras == [42]
+        app.action_quit()
+        await asyncio.sleep(0)
+
+    asyncio.run(run())

--- a/src/tests/test_tui_labeler.py
+++ b/src/tests/test_tui_labeler.py
@@ -44,3 +44,8 @@ def test_capture_screen_handles_empty_camera_list(tmp_path: Path):
     screen = CaptureScreen(tmp_path, cameras=[])
     screen._open_camera()
     assert screen._cap is None
+
+
+def test_capture_screen_converts_numeric_camera_ids(tmp_path: Path) -> None:
+    screen = CaptureScreen(tmp_path, cameras=["1"])
+    assert screen.cameras == [1]


### PR DESCRIPTION
## Summary
- track screen lock startup task and cancel it on shutdown
- document screen lock manager lifecycle
- ensure app tests cover background task cleanup
- auto-detect cameras when config lacks them and clarify warnings

## Testing
- `uv sync`
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a1bb53b3c0832c8def7a9e693f83b2