### PR TITLE
[FIX] Return to menu after capture

### DIFF
--- a/midori-ai-hello/capture_screen.py
+++ b/midori-ai-hello/capture_screen.py
@@ -148,6 +148,10 @@ class CaptureScreen(Screen):
         self._current = (self._current + 1) % len(self.cameras)
         self._open_camera()
 
+    def on_show(self) -> None:  # type: ignore[override]
+        if cv2 is not None and self._cap is None:
+            self._open_camera()
+
     def action_capture(self) -> None:
         if cv2 is None or not self._cap:
             return
@@ -207,3 +211,7 @@ class CaptureScreen(Screen):
             str(self.cameras[self._current]),
             self.dataset_path,
         )
+        if self._cap:
+            self._cap.release()
+            self._cap = None
+        self.app.switch_screen("menu")

--- a/src/tests/test_app.py
+++ b/src/tests/test_app.py
@@ -1,9 +1,12 @@
 from pathlib import Path
 import asyncio
 
+import numpy as np
+
 from midori_ai_hello.app import MidoriApp
 from midori_ai_hello.config import Config
 from midori_ai_hello.capture_screen import CaptureScreen
+from midori_ai_hello.main_menu import MainMenuScreen
 
 
 class DummyScheduler:
@@ -92,5 +95,59 @@ def test_app_detects_cameras_when_config_empty(
         assert screen.cameras == [42]
         app.action_quit()
         await asyncio.sleep(0)
+
+    asyncio.run(run())
+
+
+def test_capture_returns_to_menu(monkeypatch, tmp_path: Path) -> None:
+    cfg = Config(
+        dataset=str(tmp_path / "data"),
+        epochs=1,
+        batch=1,
+        idle_threshold=0,
+        model="yolo.pt",
+        cameras=["0"],
+    )
+    cfg.save(tmp_path / "config.yaml")
+    scheduler = DummyScheduler()
+
+    class DummyLocker:
+        async def add_active_changed_handler(self, handler):
+            self.handler = handler
+
+    app = MidoriApp(
+        tmp_path / "config.yaml", scheduler=scheduler, locker=DummyLocker()
+    )
+
+    class DummyCap:
+        def read(self):
+            return True, np.zeros((10, 10, 3), dtype=np.uint8)
+
+        def release(self):
+            pass
+
+    class DummyCV2:
+        def selectROI(self, *args, **kwargs):
+            return (0, 0, 1, 1)
+
+        def destroyAllWindows(self):
+            pass
+
+    monkeypatch.setattr("midori_ai_hello.capture_screen.cv2", DummyCV2())
+    monkeypatch.setattr("midori_ai_hello.capture_screen.save_sample", lambda *a, **k: None)
+    monkeypatch.setattr("builtins.input", lambda _: "alice")
+
+    async def run() -> None:
+        app.on_mount()
+        await asyncio.sleep(0)
+        app.switch_screen("capture")
+        await asyncio.sleep(0)
+        screen = app.screen
+        assert isinstance(screen, CaptureScreen)
+        screen._cap = DummyCap()
+        screen.action_capture()
+        await asyncio.sleep(0)
+        assert isinstance(app.screen, MainMenuScreen)
+        assert screen._cap is None
 
     asyncio.run(run())


### PR DESCRIPTION
## Summary
- release camera and navigate back to main menu after saving a capture
- reopen camera when capture screen is shown again
- test capture flow returns to MainMenuScreen

## Testing
- `uv run pytest`

------
https://chatgpt.com/codex/tasks/task_b_68a1d27438b4832caa27d4e9647f6f37