### PR TITLE
[FEAT] Add navigation hints to TUI screens

### DIFF
--- a/.codex/implementation/tui-app-skeleton.md
+++ b/.codex/implementation/tui-app-skeleton.md
@@ -14,3 +14,5 @@ capture interface and management screens:
 - `YOLOTrainingScheduler` runs in a background task with manual retrain via `r`.
 - A global footer displays `app.status`, surfacing lock state changes and long-
   running actions across all screens.
+- Individual screens expose key hints (`Esc` to return to the menu, `q` to quit)
+  and tooltips on interactive widgets for additional guidance.

--- a/.codex/implementation/whitelist-tui.md
+++ b/.codex/implementation/whitelist-tui.md
@@ -7,3 +7,5 @@ screen for managing authorised profiles.
 - Writes changes to encrypted storage using the model-derived key.
 - Shows a status indicator when the stored whitelist hash differs from the
   active model and provides a button to re-encrypt.
+- Key hints show `Esc` for returning to the main menu and `q` to quit.
+- The name input and buttons include tooltips describing their purpose.

--- a/midori-ai-hello/capture_screen.py
+++ b/midori-ai-hello/capture_screen.py
@@ -91,6 +91,8 @@ class CaptureScreen(Screen):
     BINDINGS = [
         ("c", "capture", "Capture"),
         ("n", "next_camera", "Next camera"),
+        ("escape", "menu", "Back to menu"),
+        ("q", "quit", "Quit"),
     ]
 
     def __init__(
@@ -152,6 +154,9 @@ class CaptureScreen(Screen):
             return
         self._current = (self._current + 1) % len(self.cameras)
         self._open_camera()
+
+    def action_menu(self) -> None:  # pragma: no cover - trivial
+        self.app.switch_screen("menu")
 
     def on_show(self) -> None:  # type: ignore[override]
         if cv2 is not None and self._cap is None:

--- a/midori-ai-hello/config_screen.py
+++ b/midori-ai-hello/config_screen.py
@@ -14,6 +14,11 @@ from .config import Config, load_config, update_config
 class ConfigScreen(Screen):
     """Simple configuration editor screen."""
 
+    BINDINGS = [
+        ("escape", "menu", "Back to menu"),
+        ("q", "quit", "Quit"),
+    ]
+
     def __init__(self, config_path: str | Path) -> None:
         super().__init__()
         self._config_path = Path(config_path)
@@ -21,26 +26,64 @@ class ConfigScreen(Screen):
 
     def compose(self) -> ComposeResult:  # type: ignore[override]
         yield Static("Config editor")
-        yield Input(value=self._config.dataset, placeholder="Dataset", id="dataset")
-        yield Input(value=str(self._config.epochs), placeholder="Epochs", id="epochs")
-        yield Input(value=str(self._config.batch), placeholder="Batch", id="batch")
+        yield Input(
+            value=self._config.dataset,
+            placeholder="Dataset",
+            id="dataset",
+            tooltip="Path to training dataset",
+        )
+        yield Input(
+            value=str(self._config.epochs),
+            placeholder="Epochs",
+            id="epochs",
+            tooltip="Number of training epochs",
+        )
+        yield Input(
+            value=str(self._config.batch),
+            placeholder="Batch",
+            id="batch",
+            tooltip="Batch size for training",
+        )
         yield Input(
             value=str(self._config.idle_threshold),
             placeholder="Idle threshold",
             id="idle_threshold",
+            tooltip="Seconds of inactivity before training",
         )
-        yield Input(value=self._config.model, placeholder="Model", id="model")
-        yield Input(value=self._config.backend, placeholder="Backend", id="backend")
-        yield Input(value=self._config.device, placeholder="Device", id="device")
         yield Input(
-            value=self._config.model_size, placeholder="Model size", id="model_size"
+            value=self._config.model,
+            placeholder="Model",
+            id="model",
+            tooltip="Path to YOLO model file",
+        )
+        yield Input(
+            value=self._config.backend,
+            placeholder="Backend",
+            id="backend",
+            tooltip="Inference backend to use",
+        )
+        yield Input(
+            value=self._config.device,
+            placeholder="Device",
+            id="device",
+            tooltip="Compute device (e.g., cpu or cuda)",
+        )
+        yield Input(
+            value=self._config.model_size,
+            placeholder="Model size",
+            id="model_size",
+            tooltip="Size variant of the model",
         )
         self._camera_list = ListView(*[Static(c) for c in self._config.cameras])
         yield self._camera_list
-        yield Button("Add Camera", id="add_cam")
+        yield Button(
+            "Add Camera",
+            id="add_cam",
+            tooltip="Add a new camera entry",
+        )
 
-    def action_quit(self) -> None:  # pragma: no cover - trivial
-        self.app.pop_screen()
+    def action_menu(self) -> None:  # pragma: no cover - trivial
+        self.app.switch_screen("menu")
 
     def on_button_pressed(self, event: Button.Pressed) -> None:  # type: ignore[override]
         if event.button.id == "add_cam":

--- a/midori-ai-hello/main_menu.py
+++ b/midori-ai-hello/main_menu.py
@@ -12,6 +12,8 @@ from .capture_screen import list_cameras
 class MainMenuScreen(Screen):
     """Initial menu guiding the user through application features."""
 
+    BINDINGS = [("q", "quit", "Quit")]
+
     def compose(self) -> ComposeResult:  # type: ignore[override]
         config = getattr(self.app, "_config", None)
         if config and not config.cameras and not list_cameras():
@@ -20,11 +22,27 @@ class MainMenuScreen(Screen):
                 id="help",
             )
         yield OptionList(
-            Option("Capture photos", id="capture"),
-            Option("Manage whitelist", id="whitelist"),
-            Option("View training status", id="training"),
-            Option("Configure cameras", id="config"),
-            Option("Quit", id="quit"),
+            Option(
+                "Capture photos",
+                id="capture",
+                tooltip="Capture images and label them",
+            ),
+            Option(
+                "Manage whitelist",
+                id="whitelist",
+                tooltip="Add or remove authorised users",
+            ),
+            Option(
+                "View training status",
+                id="training",
+                tooltip="Check current model training progress",
+            ),
+            Option(
+                "Configure cameras",
+                id="config",
+                tooltip="Set up available camera devices",
+            ),
+            Option("Quit", id="quit", tooltip="Exit the application"),
         )
 
     def on_option_list_option_selected(

--- a/midori-ai-hello/whitelist_screen.py
+++ b/midori-ai-hello/whitelist_screen.py
@@ -13,6 +13,11 @@ from .whitelist import WhitelistManager
 class WhitelistScreen(Screen):
     """Screen allowing users to manage the encrypted whitelist."""
 
+    BINDINGS = [
+        ("escape", "menu", "Back to menu"),
+        ("q", "quit", "Quit"),
+    ]
+
     def __init__(self, model_path: Path, config_dir: Path | None = None) -> None:
         super().__init__()
         self._manager = WhitelistManager(model_path, config_dir=config_dir)
@@ -23,11 +28,23 @@ class WhitelistScreen(Screen):
         yield self._status
         self._users = Static(id="users")
         yield self._users
-        self._name_input = Input(placeholder="Name", id="name")
+        self._name_input = Input(
+            placeholder="Name",
+            id="name",
+            tooltip="Enter the user name to add or remove",
+        )
         yield self._name_input
-        yield Button("Add", id="add")
-        yield Button("Remove", id="remove")
-        yield Button("Re-encrypt", id="reencrypt")
+        yield Button("Add", id="add", tooltip="Add the name to the whitelist")
+        yield Button(
+            "Remove",
+            id="remove",
+            tooltip="Remove the name from the whitelist",
+        )
+        yield Button(
+            "Re-encrypt",
+            id="reencrypt",
+            tooltip="Re-encrypt the stored whitelist",
+        )
         self._refresh()
 
     # ------------------------------------------------------------------
@@ -94,3 +111,6 @@ class WhitelistScreen(Screen):
             self.app.status = "Whitelist re-encrypted"
         except Exception:
             pass
+
+    def action_menu(self) -> None:  # pragma: no cover - trivial
+        self.app.switch_screen("menu")


### PR DESCRIPTION
## Summary
- add per-screen key bindings so `q` quits and `Esc` returns to the main menu
- show tooltips on menu options and inputs for clearer guidance
- document navigation hints and tooltips in TUI docs

## Testing
- `uv run pytest`


------
https://chatgpt.com/codex/tasks/task_b_68a374030948832c8146ce0ba01b4476