### PR TITLE
Replace main menu option tooltips

### DIFF
--- a/midori-ai-hello/main_menu.py
+++ b/midori-ai-hello/main_menu.py
@@ -25,24 +25,32 @@ class MainMenuScreen(Screen):
             Option(
                 "Capture photos",
                 id="capture",
-                tooltip="Capture images and label them",
             ),
             Option(
                 "Manage whitelist",
                 id="whitelist",
-                tooltip="Add or remove authorised users",
             ),
             Option(
                 "View training status",
                 id="training",
-                tooltip="Check current model training progress",
             ),
             Option(
                 "Configure cameras",
                 id="config",
-                tooltip="Set up available camera devices",
             ),
-            Option("Quit", id="quit", tooltip="Exit the application"),
+            Option("Quit", id="quit"),
+        )
+        yield Static(
+            "\n".join(
+                (
+                    "Capture photos – Capture images and label them.",
+                    "Manage whitelist – Add or remove authorised users.",
+                    "View training status – Check current model training progress.",
+                    "Configure cameras – Set up available camera devices.",
+                    "Quit – Exit the application.",
+                )
+            ),
+            id="menu-help",
         )
 
     def on_option_list_option_selected(


### PR DESCRIPTION
## Summary
- remove unsupported tooltip arguments from the main menu OptionList
- add static help text describing each menu option to replace the old tooltips

## Testing
- uv run midori_ai_hello *(interrupted after verifying no Option constructor error)*

------
https://chatgpt.com/codex/tasks/task_b_68dedbb67340832cb07c967347d46f8e