### PR TITLE
Track capture history and lock countdown in TUI footer

### DIFF
--- a/src/tests/test_screen_lock_manager.py
+++ b/src/tests/test_screen_lock_manager.py
@@ -1,5 +1,5 @@
 import asyncio
-from typing import Callable
+from typing import Any, Callable
 
 from midori_ai_hello.screen_lock_manager import ScreenLockManager
 
@@ -38,7 +38,7 @@ class FakePresence:
 
 
 def test_lock_and_unlock() -> None:
-    messages: list[str] = []
+    messages: list[tuple[str, Any]] = []
     locker = FakeLocker()
     presence = FakePresence()
 
@@ -55,7 +55,9 @@ def test_lock_and_unlock() -> None:
     asyncio.run(run())
     assert "lock" in locker.events
     assert "set_active:False" in locker.events
-    assert messages[-1] == "Unlocked"
+    assert ("presence", False) in messages
+    assert any(kind == "countdown" and value is None for kind, value in messages)
+    assert messages[-1] == ("lock", False)
 
 
 def test_presence_cancels_lock() -> None:


### PR DESCRIPTION
## Summary
- extend `MidoriApp` to record capture metadata, presence state, and lock countdowns for the footer
- report capture outcomes from `CaptureScreen` and refresh the footer when samples are saved
- emit structured screen-lock notifications and update the tests for the new manager interface

## Testing
- uv run pytest

------
https://chatgpt.com/codex/tasks/task_b_68def026d564832ca49b8d9ad39d0bd4